### PR TITLE
added `eval-after-load` demo

### DIFF
--- a/elisp-demos.org
+++ b/elisp-demos.org
@@ -6808,6 +6808,15 @@
 #+RESULTS:
 : 42
 
+* eval-after-load
+
+#+BEGIN_SRC elisp
+  (eval-after-load "elisp-mode"
+    '(progn
+       (setq answer 42)
+       (setq beast 666)))
+#+END_SRC
+
 * eval-buffer
 
 #+BEGIN_SRC elisp


### PR DESCRIPTION
added an example for `eval-after-load` since this function needs an extra `quote` around FORM and is more tricky to use then `with-eval-after-load`