### PR TITLE
Allow user files via elisp-demos-user-files, always show Demos section and include an "[Add]" button

### DIFF
--- a/elisp-demos.el
+++ b/elisp-demos.el
@@ -208,21 +208,23 @@ If set, new notes are added to the first file in this list."
 (defun elisp-demos-advice-helpful-update ()
   (let ((src (and (symbolp helpful--sym)
                   (elisp-demos--search helpful--sym))))
-    (when src
-      (save-excursion
-        (goto-char (point-min))
-        (when (re-search-forward "^References$")
-          (goto-char (line-beginning-position))
-          (let ((inhibit-read-only t))
-            (insert
-						 (helpful--heading "Demos")
-						 (propertize (elisp-demos--syntax-highlight src)
-												 'start (point)
-												 'symbol helpful--sym
-												 'keymap elisp-demos-help-keymap)
-						 (if (string= src "") "" "\n\n")
-						 (buttonize "[Add]" #'elisp-demos-add-demo helpful--sym)
-						 "\n\n")))))))
+    (save-excursion
+      (goto-char (point-min))
+      (when (re-search-forward "^References$")
+        (goto-char (line-beginning-position))
+        (let ((inhibit-read-only t))
+          (insert
+					 (helpful--heading "Demos")
+					 (if (and src (not (string= src "")))
+							 (concat
+								(propertize (elisp-demos--syntax-highlight src)
+														'start (point)
+											 			'symbol helpful--sym
+														'keymap elisp-demos-help-keymap)
+								 "\n\n")
+						 "")
+					 (buttonize "[Add]" #'elisp-demos-add-demo helpful--sym)
+					 "\n\n"))))))
 
 ;;;###autoload
 (defun elisp-demos-for-helpful ()

--- a/elisp-demos.el
+++ b/elisp-demos.el
@@ -38,28 +38,28 @@
                              elisp-demos--load-dir))
 
 (defcustom elisp-demos-user-files nil
-	"Files to search in addition to the one from the elisp-demos package.
+  "Files to search in addition to the one from the elisp-demos package.
 If set, new notes are added to the first file in this list."
-	:group 'help
-	:type '(repeat file))
+  :group 'help
+  :type '(repeat file))
 
 (defun elisp-demos--search (symbol)
-	(let (results)
-		(dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
-			(when (file-exists-p file)
-				(with-temp-buffer
-					(insert-file-contents file)
-					(delay-mode-hooks (org-mode))
-					(when-let ((pos (org-find-exact-headline-in-buffer (symbol-name symbol))))
-						(goto-char pos)
-						(org-end-of-meta-data)
-						(push (string-trim
-									 (buffer-substring-no-properties
-										(point)
-										(org-end-of-subtree)))
-									results)))))
-		(when results
-			(string-join (nreverse results) "\n\n"))))
+  (let (results)
+    (dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
+      (when (file-exists-p file)
+        (with-temp-buffer
+          (insert-file-contents file)
+          (delay-mode-hooks (org-mode))
+          (when-let ((pos (org-find-exact-headline-in-buffer (symbol-name symbol))))
+            (goto-char pos)
+            (org-end-of-meta-data)
+            (push (string-trim
+                   (buffer-substring-no-properties
+                    (point)
+                    (org-end-of-subtree)))
+                  results)))))
+    (when results
+      (string-join (nreverse results) "\n\n"))))
 
 (defun elisp-demos--syntax-highlight (orgsrc)
   (with-temp-buffer
@@ -72,15 +72,15 @@ If set, new notes are added to the first file in this list."
     (buffer-string)))
 
 (defun elisp-demos--symbols ()
-	(let (symbols)
-		(dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
-			(with-temp-buffer
-				(insert-file-contents file)
-				(goto-char (point-min))
-				(delay-mode-hooks (org-mode))
-				(while (re-search-forward "^\\* +\\(.+\\)$" nil t)
-					(push (org-entry-get (point) "ITEM") symbols))))
-		(mapcar 'intern (sort (seq-uniq symbols) #'string<))))
+  (let (symbols)
+    (dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (delay-mode-hooks (org-mode))
+        (while (re-search-forward "^\\* +\\(.+\\)$" nil t)
+          (push (org-entry-get (point) "ITEM") symbols))))
+    (mapcar 'intern (sort (seq-uniq symbols) #'string<))))
 
 (declare-function org-show-entry "org" ())
 (declare-function org-insert-heading "org" (&optional arg invisible-ok top))
@@ -100,14 +100,14 @@ If set, new notes are added to the first file in this list."
                                   (mapcar #'symbol-name symbols)
                                   nil t nil nil default-val)))))
   (cl-assert symbol)
-	(catch 'found
-		(dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
-			(with-current-buffer (find-file-noselect file)
-				(let ((pos (org-find-exact-headline-in-buffer (symbol-name symbol))))
-					(when pos
-						(goto-char pos)
-						(org-show-entry)
-						(throw 'found (point)))))))
+  (catch 'found
+    (dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
+      (with-current-buffer (find-file-noselect file)
+        (let ((pos (org-find-exact-headline-in-buffer (symbol-name symbol))))
+          (when pos
+            (goto-char pos)
+            (org-show-entry)
+            (throw 'found (point)))))))
   t)
 
 ;; Borrowed from `helpful--read-symbol'
@@ -136,7 +136,7 @@ If set, new notes are added to the first file in this list."
                                          (macrop sym))))))
   ;; Try to reuse existing window
   (let* ((file (or (car elisp-demos-user-files) elisp-demos--elisp-demos\.org))
-				 (buffer (get-file-buffer file))
+         (buffer (get-file-buffer file))
          (window (and buffer (get-buffer-window buffer))))
     (if window
         (select-window window)
@@ -214,17 +214,17 @@ If set, new notes are added to the first file in this list."
         (goto-char (line-beginning-position))
         (let ((inhibit-read-only t))
           (insert
-					 (helpful--heading "Demos")
-					 (if (and src (not (string= src "")))
-							 (concat
-								(propertize (elisp-demos--syntax-highlight src)
-														'start (point)
-											 			'symbol helpful--sym
-														'keymap elisp-demos-help-keymap)
-								"\n\n")
-						 "")
-					 (buttonize "[Add]" #'elisp-demos-add-demo helpful--sym)
-					 "\n\n"))))))
+           (helpful--heading "Demos")
+           (if (and src (not (string= src "")))
+               (concat
+                (propertize (elisp-demos--syntax-highlight src)
+                            'start (point)
+                             'symbol helpful--sym
+                            'keymap elisp-demos-help-keymap)
+                "\n\n")
+             "")
+           (buttonize "[Add]" #'elisp-demos-add-demo helpful--sym)
+           "\n\n"))))))
 
 ;;;###autoload
 (defun elisp-demos-for-helpful ()
@@ -239,34 +239,34 @@ If set, new notes are added to the first file in this list."
 (defun elisp-demos--export-json-file (json-file)
   "Export all demos as json to JSON-FILE."
   (require 'json)
-	(let ((output-buffer (generate-new-buffer " *elisp-demos-json*"))
-				title body beg end)
-		(dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
-			(with-temp-buffer
-				(insert-file-contents file)
-				(goto-char (point-min))
-				(delay-mode-hooks (org-mode))
-				(while (re-search-forward "^\\* +\\(.+\\)$" nil t)
-					(setq title (org-entry-get (point) "ITEM"))
-					(setq beg (save-excursion
-											(forward-line 1)
-											(line-beginning-position)))
-					(setq end (save-excursion
-											(if (re-search-forward "^\\* " nil t)
-													(line-beginning-position)
-												(point-max))))
-					(setq body (buffer-substring-no-properties beg end))
-					(setq title (string-trim title))
-					(setq body (string-trim body))
-					(with-current-buffer output-buffer
-						(insert
-						 (json-encode-string title) ": " (json-encode-string body) ",\n")))))
-		(with-current-buffer output-buffer
-			(delete-char -2)
-			(goto-char (point-min)) (insert "{\n")
-			(goto-char (point-max)) (insert "}\n")
-			(write-region (point-min) (point-max) json-file))
-		(kill-buffer output-buffer)))
+  (let ((output-buffer (generate-new-buffer " *elisp-demos-json*"))
+        title body beg end)
+    (dolist (file (append elisp-demos-user-files (list elisp-demos--elisp-demos.org)))
+      (with-temp-buffer
+        (insert-file-contents file)
+        (goto-char (point-min))
+        (delay-mode-hooks (org-mode))
+        (while (re-search-forward "^\\* +\\(.+\\)$" nil t)
+          (setq title (org-entry-get (point) "ITEM"))
+          (setq beg (save-excursion
+                      (forward-line 1)
+                      (line-beginning-position)))
+          (setq end (save-excursion
+                      (if (re-search-forward "^\\* " nil t)
+                          (line-beginning-position)
+                        (point-max))))
+          (setq body (buffer-substring-no-properties beg end))
+          (setq title (string-trim title))
+          (setq body (string-trim body))
+          (with-current-buffer output-buffer
+            (insert
+             (json-encode-string title) ": " (json-encode-string body) ",\n")))))
+    (with-current-buffer output-buffer
+      (delete-char -2)
+      (goto-char (point-min)) (insert "{\n")
+      (goto-char (point-max)) (insert "}\n")
+      (write-region (point-min) (point-max) json-file))
+    (kill-buffer output-buffer)))
 
 (provide 'elisp-demos)
 ;;; elisp-demos.el ends here

--- a/elisp-demos.el
+++ b/elisp-demos.el
@@ -31,11 +31,11 @@
 (require 'subr-x)
 
 (defconst elisp-demos--load-dir (file-name-directory
-                                 (or load-file-name buffer-file-name)))
+                      (or load-file-name buffer-file-name)))
 
 (defconst elisp-demos--elisp-demos.org (expand-file-name
-                                        "elisp-demos.org"
-                                        elisp-demos--load-dir))
+                             "elisp-demos.org"
+                             elisp-demos--load-dir))
 
 (defcustom elisp-demos-user-files nil
 	"Files to search in addition to the one from the elisp-demos package.
@@ -114,8 +114,8 @@ If set, new notes are added to the first file in this list."
 (defun elisp-demos--read-symbol (prompt predicate)
   (let* ((sym-here (symbol-at-point))
          (default-val
-           (when (funcall predicate sym-here)
-             (symbol-name sym-here))))
+          (when (funcall predicate sym-here)
+            (symbol-name sym-here))))
     (when default-val
       (setq prompt
             (replace-regexp-in-string
@@ -130,10 +130,10 @@ If set, new notes are added to the first file in this list."
   "Add demo for SYMBOL."
   (interactive
    (list (elisp-demos--read-symbol "Add demo: "
-                        (lambda (sym)
-                          (or (functionp sym)
-                              (special-form-p sym)
-                              (macrop sym))))))
+                                   (lambda (sym)
+                                     (or (functionp sym)
+                                         (special-form-p sym)
+                                         (macrop sym))))))
   ;; Try to reuse existing window
   (let* ((file (or (car elisp-demos-user-files) elisp-demos--elisp-demos\.org))
 				 (buffer (get-file-buffer file))
@@ -221,7 +221,7 @@ If set, new notes are added to the first file in this list."
 														'start (point)
 											 			'symbol helpful--sym
 														'keymap elisp-demos-help-keymap)
-								 "\n\n")
+								"\n\n")
 						 "")
 					 (buttonize "[Add]" #'elisp-demos-add-demo helpful--sym)
 					 "\n\n"))))))

--- a/elisp-demos.el
+++ b/elisp-demos.el
@@ -151,9 +151,9 @@ If set, new notes are added to the first file in this list."
   (insert (symbol-name symbol) "\n"
           "\n"
           "#+BEGIN_SRC elisp\n"
-          "\n"
+          (format "  (%s )\n" (symbol-name symbol))
           "#+END_SRC")
-  (search-backward "\n#+END_SRC"))
+  (search-backward ")\n#+END_SRC"))
 
 ;;; * C-h f (`describe-function')
 


### PR DESCRIPTION
Thanks for making this package! I've been slowly getting the hang of adding my notes to functions, and it's really helpful to have the examples right there. I wanted to have my own notes file so that I could try more personal notes in there before possibly contributing them, and so that I could keep those notes even after upgrading. I also wanted to make it easier to add examples right from the Helpful section for Demos. Would you consider this patch? [@xenodium](https://indieweb.social/@xenodium/111754108911084296) confirmed being able to use it too. 